### PR TITLE
Start testing on Django 1.10a1 but allow failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 build/ 
 dist/
+.eggs/
 .idea/
 .tox/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
  - 2.7
- - 3.3
  - 3.4
  - 3.5
 
@@ -12,9 +11,9 @@ env:
 sudo: false
 
 matrix:
-    exclude:
-        - python: 3.3
-          env: DJANGO_VERSION="Django>=1.9,<1.10"
+  include:
+    - python: 3.3
+      env: DJANGO_VERSION="Django>=1.8,<1.9"
 
 install:
   - pip install -q $DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 env:
  - DJANGO_VERSION="Django>=1.8,<1.9"
  - DJANGO_VERSION="Django>=1.9,<1.10"
+ - DJANGO_VERSION="Django==1.10a1"
 
 sudo: false
 
@@ -14,6 +15,9 @@ matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION="Django>=1.8,<1.9"
+  allow_failures:
+    - env: DJANGO_VERSION="Django==1.10a1"
+  fast_finish: true
 
 install:
   - pip install -q $DJANGO_VERSION

--- a/README.rst
+++ b/README.rst
@@ -51,12 +51,12 @@ You will also need to add a middleware class to listen in on responses:
 
 ::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
         ...
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
         ...
-    )
+    ]
 
 Note that ``CorsMiddleware`` needs to come before Django’s
 ``CommonMiddleware`` if you are using Django’s ``USE_ETAGS = True``

--- a/corsheaders/tests.py
+++ b/corsheaders/tests.py
@@ -1,3 +1,4 @@
+from django.conf.urls import url
 from django.http import HttpResponse
 from django.test import TestCase
 from corsheaders.middleware import CorsMiddleware, CorsPostCsrfMiddleware
@@ -10,6 +11,20 @@ from corsheaders.middleware import ACCESS_CONTROL_MAX_AGE
 from corsheaders import defaults as settings
 from mock import Mock
 from mock import patch
+
+
+def test_view(request):
+    return HttpResponse("Test view")
+
+
+def test_view_http401(request):
+    return HttpResponse('Unauthorized', status=401)
+
+
+urlpatterns = [
+    url(r'^test-view/$', test_view, name='test-view'),
+    url(r'^test-view-http401/$', test_view_http401, name='test-view-http401'),
+]
 
 
 class settings_override(object):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from corsheaders import __version__
 from setuptools import setup
 

--- a/tests.py
+++ b/tests.py
@@ -8,34 +8,23 @@ def run_tests():
     import django
     from django.conf import global_settings
     from django.conf import settings
-    try:
-        settings.configure(
-            INSTALLED_APPS=[
-                'corsheaders',
-            ],
-            DATABASES={
-                'default': {
-                    'ENGINE': 'django.db.backends.sqlite3',
-                    'TEST_NAME': ':memory:',
-                },
+
+    middleware = list(global_settings.MIDDLEWARE_CLASSES)
+    middleware.append('corsheaders.middleware.CorsMiddleware')
+
+    settings.configure(
+        INSTALLED_APPS=[
+            'corsheaders',
+        ],
+        DATABASES={
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'TEST_NAME': ':memory:',
             },
-            MIDDLEWARE_CLASSES=global_settings.MIDDLEWARE_CLASSES + (
-                'corsheaders.middleware.CorsMiddleware',),
-        )
-    except TypeError:  # django 1.9+
-        settings.configure(
-            INSTALLED_APPS=[
-                'corsheaders',
-            ],
-            DATABASES={
-                'default': {
-                    'ENGINE': 'django.db.backends.sqlite3',
-                    'TEST_NAME': ':memory:',
-                },
-            },
-            MIDDLEWARE_CLASSES=global_settings.MIDDLEWARE_CLASSES + [
-                'corsheaders.middleware.CorsMiddleware',],
-        )
+        },
+        MIDDLEWARE_CLASSES=middleware,
+    )
+
     if hasattr(django, 'setup'):
         django.setup()
 

--- a/tests.py
+++ b/tests.py
@@ -22,6 +22,7 @@ def run_tests():
                 'TEST_NAME': ':memory:',
             },
         },
+        ROOT_URLCONF='corsheaders.tests',
         MIDDLEWARE_CLASSES=middleware,
     )
 

--- a/tests.py
+++ b/tests.py
@@ -9,22 +9,28 @@ def run_tests():
     from django.conf import global_settings
     from django.conf import settings
 
-    middleware = list(global_settings.MIDDLEWARE_CLASSES)
+    if django.VERSION >= (1, 10):
+        middleware_setting = 'MIDDLEWARE'
+    else:
+        middleware_setting = 'MIDDLEWARE_CLASSES'
+
+    middleware = list(getattr(global_settings, middleware_setting) or [])
     middleware.append('corsheaders.middleware.CorsMiddleware')
 
-    settings.configure(
-        INSTALLED_APPS=[
+    config = {
+        'INSTALLED_APPS': [
             'corsheaders',
         ],
-        DATABASES={
+        'DATABASES': {
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
                 'TEST_NAME': ':memory:',
             },
         },
-        ROOT_URLCONF='corsheaders.tests',
-        MIDDLEWARE_CLASSES=middleware,
-    )
+        'ROOT_URLCONF': 'corsheaders.tests',
+        middleware_setting: middleware,
+    }
+    settings.configure(**config)
 
     if hasattr(django, 'setup'):
         django.setup()


### PR DESCRIPTION
As a precursor for supporting Django 1.10's new style of middleware, this PR:
* Adds some new end-to-end tests that catch issues with Django 1.10 that the existing unit tests did not.
* Makes the test runner use the new `MIDDLEWARE` setting rather than `MIDDLEWARE_CLASSES` under Django 1.10.
* Adds Django 1.10 to the Travis run, but allows failures (it's currently not passing).

See the individual commit messages for more details.

Another PR can then more easily iterate on adding support for the new style Django 1.10 middleware, by following:
https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

Note: django-cors-middleware should already be compatible with Django 1.10 if used via the old-style `MIDDLEWARE_CLASSES` setting, it's only if users try to add it to `MIDDLEWARE` that they will see failures. 