### PR TITLE
Allow for a null origin (file URL) in the whitelist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,9 @@ Default:
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Specify a list of origin hostnames that are authorized to make a
-cross-site HTTP request
+cross-site HTTP request.  To allow requests from a file URL (e.g.
+``file:///home/bob/index.html``) add the string ``null`` to the
+whitelist.
 
 Example:
 
@@ -93,8 +95,12 @@ Example:
 
     CORS_ORIGIN_WHITELIST = (
         'google.com',
-        'hostname.example.com'
+        'hostname.example.com',
+        'localhost:8000',
+        'null'
     )
+
+Note that ``localhost`` is not the same as ``localhost:8000``.
 
 Default:
 

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -145,7 +145,8 @@ class CorsMiddleware(object):
 
     def origin_not_found_in_white_lists(self, origin, url):
         return (url.netloc not in settings.CORS_ORIGIN_WHITELIST and
-                not self.regex_domain_match(origin))
+                not self.regex_domain_match(origin) and
+                not (origin == "null" and "null" in settings.CORS_ORIGIN_WHITELIST))
 
     def regex_domain_match(self, origin):
         for domain_pattern in settings.CORS_ORIGIN_REGEX_WHITELIST:


### PR DESCRIPTION
This patch allows for a straight-forward way of adding a file based URL (null origin) to the whitelist