### PR TITLE
Add Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 env:
  - DJANGO_VERSION="Django>=1.8,<1.9"
  - DJANGO_VERSION="Django>=1.9,<1.10"
- - DJANGO_VERSION="Django==1.10b1"
+ - DJANGO_VERSION="Django>=1.10,<1.11"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION="Django>=1.8,<1.9"
-  allow_failures:
-    - env: DJANGO_VERSION="Django==1.10b1"
   fast_finish: true
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ Supported versions of Python and Django :
 +------------------+--------------+--------------+--------------+--------------+
 | **Django 1.9**   | YES          |              | YES          | YES          |
 +------------------+--------------+--------------+--------------+--------------+
+| **Django 1.10**  | YES          |              | YES          | YES          |
++------------------+--------------+--------------+--------------+--------------+
 
 Setup
 -----
@@ -51,7 +53,8 @@ You will also need to add a middleware class to listen in on responses:
 
 ::
 
-    MIDDLEWARE_CLASSES = [
+    # Use `MIDDLEWARE_CLASSES` prior to Django 1.10
+    MIDDLEWARE = [
         ...
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -15,6 +15,13 @@ except ImportError:
     except ImportError:
         from django.apps.apps.get_model import get_model
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
 from corsheaders import defaults as settings
 
 
@@ -26,7 +33,7 @@ ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
 ACCESS_CONTROL_MAX_AGE = 'Access-Control-Max-Age'
 
 
-class CorsPostCsrfMiddleware(object):
+class CorsPostCsrfMiddleware(MiddlewareMixin):
 
     def _https_referer_replace_reverse(self, request):
         """
@@ -48,7 +55,7 @@ class CorsPostCsrfMiddleware(object):
         return None
 
 
-class CorsMiddleware(object):
+class CorsMiddleware(MiddlewareMixin):
 
     def _https_referer_replace(self, request):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,14 @@ downloadcache = {toxworkdir}/cache/
 envlist =
     py27-django18,
     py27-django19,
+    py27-django110,
     py33-django18,
     py34-django18,
     py34-django19,
+    py34-django110,
     py35-django18,
     py35-django19,
+    py35-django110,
 
 
 [testenv]
@@ -20,6 +23,9 @@ deps = django<1.9
 [django19]
 deps = django<1.10
 
+[django110]
+deps = django<1.11
+
 
 [testenv:py27-django18]
 basepython = python2.7
@@ -28,6 +34,10 @@ deps = {[django18]deps}
 [testenv:py27-django19]
 basepython = python2.7
 deps = {[django19]deps}
+
+[testenv:py27-django110]
+basepython = python2.7
+deps = {[django110]deps}
 
 
 [testenv:py33-django18]
@@ -43,6 +53,10 @@ deps = {[django18]deps}
 basepython = python3.4
 deps = {[django19]deps}
 
+[testenv:py34-django110]
+basepython = python3.4
+deps = {[django110]deps}
+
 
 [testenv:py35-django18]
 basepython = python3.5
@@ -51,3 +65,7 @@ deps = {[django18]deps}
 [testenv:py35-django19]
 basepython = python3.5
 deps = {[django19]deps}
+
+[testenv:py35-django110]
+basepython = python3.5
+deps = {[django110]deps}


### PR DESCRIPTION
Simply submitting @edmorley's work from #19. It seems like there was some issues with the way the middleware was implemented, but that this may have been fixed between alpha and beta. Per the comments in #19 `test_middleware_integration_get_auth_view` was failing, but this seems to work now?
