### PR TITLE
Add 'Origin' to 'Vary' header of CORS responses

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -7,6 +7,7 @@ except ImportError:
     from urllib.parse import urlparse
 
 from django.apps import apps
+from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 
 from corsheaders import defaults as settings
@@ -118,9 +119,11 @@ class CorsMiddleware(MiddlewareMixin):
                     not self.check_signal(request)):
                 return response
 
-            response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*" if (
-                settings.CORS_ORIGIN_ALLOW_ALL and
-                not settings.CORS_ALLOW_CREDENTIALS) else origin
+            if settings.CORS_ORIGIN_ALLOW_ALL and not settings.CORS_ALLOW_CREDENTIALS:
+                response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
+            else:
+                response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+                patch_vary_headers(response, ['Origin'])
 
             if len(settings.CORS_EXPOSE_HEADERS):
                 response[ACCESS_CONTROL_EXPOSE_HEADERS] = ', '.join(

--- a/corsheaders/tests.py
+++ b/corsheaders/tests.py
@@ -395,6 +395,20 @@ class TestCorsMiddlewareProcessResponse(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertAccessControlAllowOriginEquals(response, 'http://foobar.it')
 
+    def test_middleware_integration_options(self, settings):
+        settings.CORS_MODEL = None
+        settings.CORS_URLS_REGEX = '^.*$'
+        settings.CORS_ALLOW_CREDENTIALS = True
+        settings.CORS_ORIGIN_ALLOW_ALL = True
+        response = self.client.options(
+            '/test-view/',
+            HTTP_ORIGIN='http://foobar.it',
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response[ACCESS_CONTROL_ALLOW_ORIGIN], 'http://foobar.it')
+        self.assertEqual(response['Vary'], 'Origin')
+
     def test_middleware_integration_get_auth_view(self, settings):
         """
         It's not clear whether the header should still be set for non-HTTP200


### PR DESCRIPTION
This pulls in the upstream PR https://github.com/adamchainz/django-cors-headers/pull/156

>Only when not allowing all origins, as per the
[Mozilla CORS docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
>Fixes #63.

**Issue(s)** : 
Fixes #10 